### PR TITLE
[dl] update setting so sequencer defaults to keep state

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -196,3 +196,6 @@ bEnableAnalytics=True
 bEnableCrashes=True
 bEnableDistribute=True
 AppSecretIOS=APPCENTER_SECRET
+
+[/Script/LevelSequence.LevelSequence]
+DefaultCompletionMode=KeepState


### PR DESCRIPTION
Lighting will be using sequences where we want to keep state. As this applies to the majority of how we will be using sequences I think it makes sense to make this the default setting rather than having to check "Pause at End" for every sequence actor that we create. Let me know if you think otherwise